### PR TITLE
add support for the agent property in options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-request",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A zero-dependency stripped-down http client request module based on the http://npm.im/request API",
   "main": "request.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-request",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "A zero-dependency stripped-down http client request module based on the http://npm.im/request API",
   "main": "request.js",
   "directories": {

--- a/request.js
+++ b/request.js
@@ -174,5 +174,9 @@ function formatOptions(options) {
     })
   }
 
+  if (options.agent != null) {
+    opts.agent = options.agent
+  }
+
   return opts
 }


### PR DESCRIPTION
This commit adds support for using the standard http `agent` property in
the request options, passing it on to the options actually used to make the
request.

Test case added to ensure the request gets passed through the agent.
