### PR TITLE
CORS fix

### DIFF
--- a/request.js
+++ b/request.js
@@ -164,6 +164,7 @@ function formatOptions(options) {
       port: Number(u.port) || (protocol === "https:" ? 443 : 80),
       path: u.path,
       headers: headers,
+      withCredentials: options.withCredentials || false
   }
 
   if (protocol === 'https:') {


### PR DESCRIPTION
@demipel8's CORS fix frm #3 

fixed without semicolons

>Added the `withCredentials` option to avoid the following error on chrome: Cannot use wildcard in Access-Control-Allow-Origin when credentials flag is true.

>withCredentials added to options