### PR TITLE
Promise reject on error status codes only (>=400)

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -7,7 +7,7 @@ function requestPromise(opts) {
     request(opts, function(err, response, body) {
       if (err) {
         reject(err)
-      } else if (response.statusCode !== 200) {
+      } else if (response.statusCode >= 400) {
         err = new Error('Status code ' + response.statusCode)
         err.response = response
         err.body = body


### PR DESCRIPTION
Take a less strict approach on valid status codes, actually only 400 and higher are errors.
http://www.restapitutorial.com/httpstatuscodes.html or
https://en.wikipedia.org/wiki/List_of_HTTP_status_codes