### PR TITLE
Allow the same behavior with promise as without

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ var requestPromise = require("client-request/promise")
 
 requestPromise(options).then(function (result) {
   if (result.response.statusCode === 201) {
-    console.log(result.response.headers.location);
+    console.log(result.response.headers.location)
   } else {
-    console.log(result.body);
+    console.log(result.body)
   }
 }).catch(err){
-  console.log(err);
-});
+  console.log(err)
+})
 ```
 
 ```javascript
@@ -64,10 +64,10 @@ var requestPromise = require("client-request/promise")
 // ONLY in ES2016 and later, you can await a promise in an async function (generator)
 async function(){
   try {
-    let result = await requestPromise(options);
-    console.log(result.response.headers.location);
+    let result = await requestPromise(options)
+    console.log(result.response.headers.location)
   } catch (err) {
-    console.log(err);
+    console.log(err)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,29 @@ var req = request(options, function callback(err, response, body) {
 ```javascript
 var requestPromise = require("client-request/promise")
 
-requestPromise(options).then(function (body) {
-  console.log(body)
-})
+requestPromise(options).then(function (result) {
+  if (result.response.statusCode === 201) {
+    console.log(result.response.headers.location);
+  } else {
+    console.log(result.body);
+  }
+}).catch(err){
+  console.log(err);
+});
+```
+
+```javascript
+var requestPromise = require("client-request/promise")
+
+// ONLY in ES2016 and later, you can await a promise in an async function (generator)
+async function(){
+  try {
+    let result = await requestPromise(options);
+    console.log(result.response.headers.location);
+  } catch (err) {
+    console.log(err);
+  }
+}
 ```
 
 WHY DID I MAKE THIS?

--- a/promise.js
+++ b/promise.js
@@ -3,8 +3,8 @@ const request = require('./request')
 module.exports = requestPromise
 
 function requestPromise(opts) {
-  return new Promise(function(resolve, reject) {
-    request(opts, function(err, response, body) {
+  return new Promise(function (resolve, reject) {
+    request(opts, function (err, response, body) {
       if (err) {
         reject(err)
       } else if (response.statusCode >= 400) {
@@ -13,7 +13,11 @@ function requestPromise(opts) {
         err.body = body
         reject(err)
       } else {
-        resolve(body)
+        var result = {
+          body: body,
+          response: response
+        };
+        resolve(result);
       }
     })
   })

--- a/promise.js
+++ b/promise.js
@@ -16,8 +16,8 @@ function requestPromise(opts) {
         var result = {
           body: body,
           response: response
-        };
-        resolve(result);
+        }
+        resolve(result)
       }
     })
   })


### PR DESCRIPTION
The missing response information in the promise version breaks the symmetry of the code between the promise and callback versions. For the promise, I recommend returning the body and response as an object so that this is rectified.

This is a **breaking** change for people already using the promise version of the code.