### PR TITLE
set code = 'ECONNRESET' on timeout errors

### DIFF
--- a/request.js
+++ b/request.js
@@ -127,6 +127,7 @@ function request (requestOptions, callback) {
     totalTimeout = setTimeout(function onTimeout () {
       req.abort()
       var err = new Error('client request timeout')
+      err.statusCode = 408
       return reply(err)
     }, requestOptions.timeout)
 
@@ -134,6 +135,7 @@ function request (requestOptions, callback) {
     req.setTimeout(requestOptions.timeout, function onSocketTimeout () {
       req.abort()
       var err = new Error('Socket Timeout on client request')
+      err.statusCode = 408
       return reply(err)
     })
   }

--- a/request.js
+++ b/request.js
@@ -127,7 +127,7 @@ function request (requestOptions, callback) {
     totalTimeout = setTimeout(function onTimeout () {
       req.abort()
       var err = new Error('client request timeout')
-      err.statusCode = 408
+      err.code = 'ECONNRESET'
       return reply(err)
     }, requestOptions.timeout)
 
@@ -135,7 +135,7 @@ function request (requestOptions, callback) {
     req.setTimeout(requestOptions.timeout, function onSocketTimeout () {
       req.abort()
       var err = new Error('Socket Timeout on client request')
-      err.statusCode = 408
+      err.code = 'ECONNRESET'
       return reply(err)
     })
   }

--- a/test/index.js
+++ b/test/index.js
@@ -120,6 +120,7 @@ require('./test_server')(function ready (servers) {
     request(opts, (err, response, body) => {
       t.ok(err, 'expect an error')
       t.equal(err.message, 'client request timeout', 'correct error message')
+      t.equal(err.code, 'ECONNRESET', 'correct error code')
       t.notOk(response.statusCode, 'no statusCode (timed out)')
       t.notOk(body, 'no body')
       t.end()
@@ -134,6 +135,7 @@ require('./test_server')(function ready (servers) {
     promise(opts).catch((err) => {
       t.ok(err, 'expect an error')
       t.equal(err.message, 'client request timeout', 'correct error message')
+      t.equal(err.code, 'ECONNRESET', 'correct error code')
       t.end()
     })
   })
@@ -316,6 +318,7 @@ require('./test_server')(function ready (servers) {
     request(opts, (err, response, body) => {
       t.ok(err, 'expect an error')
       t.equal(err.message, 'client request timeout', 'correct error message')
+      t.equal(err.code, 'ECONNRESET', 'correct error code')
       t.notOk(response.statusCode, 'no statusCode (timed out)')
       t.notOk(body, 'no body')
       t.end()
@@ -451,6 +454,7 @@ require('./test_server')(function ready (servers) {
     request(opts, (err, response, body) => {
       t.ok(err, 'expect an error')
       t.equal(err.message, 'client request timeout', 'correct error message')
+      t.equal(err.code, 'ECONNRESET', 'correct error code')
       t.notOk(response.statusCode, 'no statusCode (timed out)')
       t.notOk(body, 'no body')
       t.end()


### PR DESCRIPTION
This allows for easy differentiation of timeout errors, which
client wrappers may often want to attempt a retry when
encountered.

Fixes https://github.com/brycebaril/client-request/issues/14

@brycebaril 